### PR TITLE
Ensure Docker image names are legal

### DIFF
--- a/rpmbuild/__init__.py
+++ b/rpmbuild/__init__.py
@@ -163,7 +163,9 @@ class Packager(object):
 
     @property
     def image_name(self):
-        return 'rpmbuild-%s' % self.context
+        ## slashes are illegal in an image name; interpreted as a registry
+        ## dashes are also illegal
+        return 'rpmbuild_%s' % str(self.context).replace("/", "_")
 
     @property
     def image(self):

--- a/rpmbuild/build.py
+++ b/rpmbuild/build.py
@@ -41,7 +41,6 @@ Docker Options:
 from __future__ import print_function
 
 import json
-import os
 import sys
 
 from docopt import docopt

--- a/tests/packager_test.py
+++ b/tests/packager_test.py
@@ -27,7 +27,7 @@ class PackagetTestCase(unittest.TestCase):
         context = PackagerContext.return_value
         context.__str__.return_value = 'foo'
         packager = Packager(context, {})
-        self.assertEqual(packager.image_name, 'rpmbuild-foo')
+        self.assertEqual(packager.image_name, 'rpmbuild_foo')
 
     def test_packager_image_with_matches(self, PackagerContext):
         context = PackagerContext.return_value
@@ -87,7 +87,7 @@ class PackagetTestCase(unittest.TestCase):
         packager = Packager(context, {})
         packager.client.build = MagicMock()
         packager.build_image()
-        packager.client.build.assert_called_with('/tmp', tag='rpmbuild-foo', stream=True)
+        packager.client.build.assert_called_with('/tmp', tag='rpmbuild_foo', stream=True)
 
     def test_packager_build_package(self, PackagerContext):
         context = PackagerContext.return_value


### PR DESCRIPTION
Docker 1.4.1 doesn't like slashes in the image name.