### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include setup.py


### PR DESCRIPTION
This adds a simple MANIFEST.in that includes `setup.py`.  It's required to use `pex` for building a self-contained archive.